### PR TITLE
servicio usuario admin para cambiar el estado de lugares seguros

### DIFF
--- a/api2/src/controllers/auth.js
+++ b/api2/src/controllers/auth.js
@@ -82,7 +82,7 @@ const createNewUser = async(req,res)=>{
         const {name,email,password} = req.body;
         const data = {name, email,role:"regular"}
         const token = await servicesAuth0.getAccessToken();
-        const auth0data = {userData: {data:{email,password},metadata:{name}}}
+        const auth0data = {userData: {data:{email,password},metadata:data}}
         const createUser = await servicesAuth0.createAuth0User({...auth0data,accessToken: token.data.access_token})
         if(createUser.error)return res.status(400).json(createUser.msj)
         const saveUserDB = await servicesUser.createNewUser(data)
@@ -107,6 +107,7 @@ const login = async(req,res)=>{
         throw error 
     }
 };
+
 
 
 

--- a/api2/src/controllers/safeplace.js
+++ b/api2/src/controllers/safeplace.js
@@ -17,5 +17,16 @@ const postSafePlace = async (req,res) =>{
     }
 };
 
+const changeStatusSafePlace = async (req,res) =>{
+    console.log(req.user)
+    const {id,status} = req.params;
+    const {description_status = ""} = req.body;
+    const statusChange = await ServicesSafePlace.editSafePlaceByPK({status,description_status},id);
+    res.status(200).json({success:true})
+};
 
-module.exports = {getSafePlaces,postSafePlace}
+
+
+
+
+module.exports = {getSafePlaces,postSafePlace,changeStatusSafePlace}

--- a/api2/src/middlewares/safePlace.js
+++ b/api2/src/middlewares/safePlace.js
@@ -1,0 +1,10 @@
+const {User} = require('../db');
+
+
+exports.isAdminUser = async (req,res,next) => {
+    const {email} = req.user;
+    const userAdmin = await User.findOne({where:{role:"admin",email}})
+    if(!userAdmin)return res.status(401).json("No es un usuario admin");
+    next();
+    
+};

--- a/api2/src/models/User.js
+++ b/api2/src/models/User.js
@@ -14,6 +14,7 @@ const  { sequelize } = require('../db');
         email: {
             type: DataTypes.STRING,
             allowNull: false,
+            unique:true
         },
         role:{
             type:DataTypes.STRING,

--- a/api2/src/models/safePlace.js
+++ b/api2/src/models/safePlace.js
@@ -13,10 +13,6 @@ module.exports = function (sequelize) {
             type: DataTypes.STRING,
             allowNull: false,
         },
-        lastname:{
-            type: DataTypes.STRING,
-            allowNull:false,
-        },
         country:{
             type: DataTypes.STRING,
             allowNull:false,
@@ -61,7 +57,14 @@ module.exports = function (sequelize) {
             type: DataTypes.STRING,
             allowNull: false
         },
-        
+        status:{
+            type:DataTypes.ENUM("accepted","pending","warning","rejected"),
+            allowNull: false
+        },
+        description_status:{
+            type:DataTypes.STRING,
+            allowNull:true
+        }
     }, 
     { timestamps: false }
     );

--- a/api2/src/routes/safeplace.js
+++ b/api2/src/routes/safeplace.js
@@ -1,15 +1,17 @@
 const {Router} = require ('express');
 const {getSafePlaces} = require ('../controllers/safeplace');
-const { postSafePlace } = require('../controllers/safeplace');
+const { postSafePlace,changeStatusSafePlace } = require('../controllers/safeplace');
 const {postSafePlaceSchema} = require('../schemas/safePlace');
 const {validateBody} =require('../middlewares/validateSchema');
 const {checkJwt} = require('../middlewares/jwt');
+const {isAdminUser} = require('../middlewares/safePlace');
 
 const router = Router();
 
 router.get('/',getSafePlaces);
 //router.post('/',checkJwt,validateBody(postSafePlaceSchema),postSafePlace);
 router.post('/',checkJwt,validateBody(postSafePlaceSchema),postSafePlace);
+router.post('/:id/:status',checkJwt,isAdminUser,changeStatusSafePlace);
 
 
 module.exports = router;

--- a/api2/src/schemas/safePlace.js
+++ b/api2/src/schemas/safePlace.js
@@ -2,7 +2,6 @@ const Joi = require('joi');
 
 const postSafePlaceSchema = Joi.object({
     name:Joi.string().required(),
-    lastname:Joi.string(),
     country:Joi.string().required(),
     town:Joi.string().required(),
     street: Joi.string().required(),
@@ -14,6 +13,7 @@ const postSafePlaceSchema = Joi.object({
     telephone:Joi.string().required(),
     keyword:Joi.string().required(),
     relation:Joi.string().required(),
+    status:Joi.string(),
     userId:Joi.number().required()
 });
 module.exports ={postSafePlaceSchema}

--- a/api2/src/services/safeplace.js
+++ b/api2/src/services/safeplace.js
@@ -1,3 +1,4 @@
+
 const {SafePlace,User} = require('../db');
 const clientId = process.env
 
@@ -5,6 +6,7 @@ const clientId = process.env
 async function getSafePlaces(){
     try{
         return await SafePlace.findAll({
+            where:{status: "accepted"},
             include:[{
                 model:User,
                 as: 'safePlaceCreator',
@@ -19,10 +21,22 @@ async function getSafePlaces(){
 };
 
 async function postSafePlace(data){
-    let createNewSafePlace = await SafePlace.create(data)
+    let createNewSafePlace = await SafePlace.create({...data,status:"pending"})
+};
+
+
+
+async function editSafePlaceByPK(body,id){
+    try{
+        await SafePlace.update({...body},{where:{id}})
+    }
+    catch(error){
+        console.log(error)
+        throw error
+    }
 };
 
 
 
 
-module.exports = {getSafePlaces,postSafePlace}
+module.exports = {getSafePlaces,postSafePlace,editSafePlaceByPK}


### PR DESCRIPTION
chicas este servicio sirve para las usuarias admin, pueden cambiar el status de ese lugar seguro , se crean con un status en "pending" , puede cambiarse a "accepted", "warning" o "rejected"
devuelve "success: true" si el cambio se hizo ok, lo que si el role del usuario lo cambio a mano desde la base de datos, para poder pegarle a este servicio. 
con Flor quedamos que no se van a borrar esos lugares seguros de la DB si son rechazados, solo se le va a cambiar el status y tienen que poner una breve  descripcion por body (description_status)que explique el porque fue rechazado.